### PR TITLE
Fix rscope-pop-mark: marker-buffer is killed

### DIFF
--- a/rscope.el
+++ b/rscope.el
@@ -313,6 +313,7 @@ The first hook returning a non nil value wins.")
     (setq old-buffer-killable
 	  (and (with-current-buffer old-buffer
 		 (and (boundp 'rscope-auto-open) rscope-auto-open))
+	       (not (equal marker-buffer old-buffer))
 	       (not (rscope-ring-bufferp old-buffer))))
     
     (if marker-buffer


### PR DESCRIPTION
When current buffer is the same as last mark's one,
rscope-pop-mark will delete the current buffer and the showed window
will be wrong.
Prevent this by checking that the marker-buffer is not the current one.

Signed-off-by: Sylvain Chouleur <sylvain.chouleur@gmail.com>